### PR TITLE
feat: Add URL capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = "1.0.164"
 serde_derive = "1.0.164"
 almanac = "0.4.0"
 ctrlc = "3.4.0"
+reqwest = { version = "0.11", features = ["blocking"] }
 
 [dependencies.ical]
 version = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ cargo install calio
 
 Then you'll be able to run `calio` from whichever directory you're in.
 
-
 ## How-To
 
 **Calio** is easy to use, just provide a file path or stdin to read the
@@ -24,6 +23,7 @@ ics contents:
 
 ```
 calio /some/file/path/cal.ics
+calio https://gist.githubusercontent.com/DeMarko/6142417/raw/1cd301a5917141524b712f92c2e955e86a1add19/sample.ics
 cat /some/file/path.cal.ics | calio
 ```
 


### PR DESCRIPTION
This commit allows the value specified as the first commandline argument to be a URL, in which case it is downloaded (via a blocking reqwest) and parsed into a Calendar struct

I couldn't find many ICS URLs online, but I use them a bunch for my project [eskom-calendar](https://github.com/beyarkay/eskom-calendar/), so here are some of those as examples:

```
╰→ cargo run -- https://github.com/beyarkay/eskom-calendar/releases/download/latest/buffalo-city-block-1.ics
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/calio 'https://github.com/beyarkay/eskom-calendar/releases/download/latest/buffalo-city-block-1.ics'`

Sun Jun 11 2023
    16:00-18:00 🔌BuffaloCityBlock1 Stage 4 😣
                This event shows that there will be loadshedding on Sunday from 16:00 to Sunday at 18:00 in the load shedding area buffalo-city-block-1.

Mon Jun 12 2023
    21:00-00:00 🔌BuffaloCityBlock1 Stage 3 😟
                This event shows that there will be loadshedding on Monday from 21:00 to Tuesday at 00:00 in the load shedding area buffalo-city-block-1.

Wed Jun 14 2023
    16:00-18:00 🔌BuffaloCityBlock1 Stage 3 😟
                This event shows that there will be loadshedding on Wednesday from 16:00 to Wednesday at 18:00 in the load shedding area buffalo-city-block-1.

    18:00-19:00 ⚠️  End of schedule
                This is the end of the known loadshedding schedule.
```