### PR TITLE
feat: Add a flag to hide the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ cargo install calio
 
 Then you'll be able to run `calio` from whichever directory you're in.
 
-
 ## How-To
 
 **Calio** is easy to use, just provide a file path or stdin to read the
@@ -31,6 +30,7 @@ And also comes with the following options:
 
 ```
 --keep-alive  Keep the app running and do not exit on stdout.
+--hide-desc   Don't show the event's description.
 -h, --help    Print help information.
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn print_day(date: Date) {
     println!("\n{}", date.format("%a %b %e %Y").green().bold())
 }
 
-fn print_event(event: &Event, ustart: bool, uend: bool) {
+fn print_event(event: &Event, ustart: bool, uend: bool, hide_desc: bool) {
     let start = if ustart {
         "-----".to_string()
     } else {
@@ -40,13 +40,13 @@ fn print_event(event: &Event, ustart: bool, uend: bool) {
         event.location.purple()
     );
 
-    if !event.description.is_empty() {
+    if !hide_desc && !event.description.is_empty() {
         let description = str::replace(&event.description, "\\n", &format!("\n{}", " ".repeat(16)));
         println!("{}{}", " ".repeat(16), description.cyan());
     }
 }
 
-fn print_events(events: impl Iterator<Item = Event>) {
+fn print_events(events: impl Iterator<Item = Event>, hide_desc: bool) {
     let mut day = Date::new();
     let mut unfinish: Vec<Event> = vec![];
 
@@ -59,9 +59,9 @@ fn print_events(events: impl Iterator<Item = Event>) {
                     for (i, event) in unfinish.clone().iter().enumerate() {
                         if event.end_date() <= day + Duration::days(1) {
                             unfinish.remove(i);
-                            print_event(event, true, false);
+                            print_event(event, true, false, hide_desc);
                         } else {
-                            print_event(event, true, true);
+                            print_event(event, true, true, hide_desc);
                         }
                     }
                 }
@@ -72,10 +72,10 @@ fn print_events(events: impl Iterator<Item = Event>) {
         }
 
         if event.end_date() > event.start + Duration::days(1) {
-            print_event(&event, false, true);
+            print_event(&event, false, true, hide_desc);
             unfinish.push(event);
         } else {
-            print_event(&event, false, false);
+            print_event(&event, false, false, hide_desc);
         }
     }
 
@@ -85,9 +85,9 @@ fn print_events(events: impl Iterator<Item = Event>) {
         for (i, event) in unfinish.clone().iter().enumerate() {
             if event.end_date() <= day + Duration::days(1) {
                 unfinish.remove(i);
-                print_event(event, true, false);
+                print_event(event, true, false, hide_desc);
             } else {
-                print_event(event, true, true);
+                print_event(event, true, true, hide_desc);
             }
         }
     }
@@ -107,22 +107,26 @@ Tiny CLI tool that helps to visualize iCal file content in the terminal.
 {}:
     {}    Keep the app running and do not exit on stdout.
     {}          Display this message and exit.
+    {}     Don't show the event's description.
 
 {}:
     cat ~/invite.ics | calio
     calio ~/invite.ics --keep-alive
+    calio ~/invite.ics --hide-desc
 ",
         "calio".green(),
         "USAGE:".yellow(),
         "OPTIONS:".yellow(),
         "--keep-alive".green(),
         "--help".green(),
+        "--hide-desc".green(),
         "EXAMPLE".yellow()
     );
 
     let args: Vec<_> = env::args().collect();
     let is_stdin_empty: bool = atty::is(atty::Stream::Stdin);
     let mut keep_alive: bool = false;
+    let hide_desc = args.iter().any(|arg| arg == "--hide-desc");
 
     if is_stdin_empty && args.len() < 2 {
         // no args no stdin
@@ -144,7 +148,7 @@ Tiny CLI tool that helps to visualize iCal file content in the terminal.
         let stdin = std::io::stdin();
         let buf = BufReader::new(stdin);
         let calendars = Calendar::parse(buf).unwrap();
-        print_events(calendars.iter());
+        print_events(calendars.iter(), hide_desc);
     };
 
     if is_stdin_empty {
@@ -163,7 +167,7 @@ Tiny CLI tool that helps to visualize iCal file content in the terminal.
         let file = File::open(&args[1]).unwrap();
         let buf = BufReader::new(file);
         let calendars = Calendar::parse(buf).unwrap();
-        print_events(calendars.iter());
+        print_events(calendars.iter(), hide_desc);
     };
 
     let running = Arc::new(AtomicBool::new(keep_alive));


### PR DESCRIPTION
This commit adds a flag to not show any of the event descriptions, like a summary view.

Some calendars have really long event descriptions containing links and all sorts of garbage. It's super handy to just see the event name. Consider:

```
╰→ calio buffalo-city-block-1.ics --hide-desc
Sun Jun 11 2023
    16:00-18:00 🔌BuffaloCityBlock1 Stage 4 😣

Mon Jun 12 2023
    21:00-00:00 🔌BuffaloCityBlock1 Stage 3 😟

Wed Jun 14 2023
    16:00-18:00 🔌BuffaloCityBlock1 Stage 3 😟
    18:00-19:00 ⚠️  End of schedule
```

versus the full version:

```
╰→ calio buffalo-city-block-1.ics

Sun Jun 11 2023
    16:00-18:00 🔌BuffaloCityBlock1 Stage 4 😣
                This event shows that there will be loadshedding on Sunday from 16:00 to Sunday at 18:00 in the load shedding area buffalo-city-block-1.

                When new loadshedding schedules are announced, your calendar will be automatically updated to show when your power will be off.

                While these new schedules are calculated immediately, it can sometimes take a bit of time for your calendar app (ie Google Calendar, Apple iCalendar, or Outlook) to fetch the updated schedules. Often you can set the update frequency in the settings of your calendar app.

                ---

                Incorrect? Open an issue here: https://github.com/beyarkay/eskom-calendar/issues/new

                Generated by Boyd Kane's eskom-calendar: https://eskomcalendar.co.za/ec?calendar=buffalo-city-block-1.ics.

                National loadshedding information scraped from https://twitter.com/Eskom_SA/status/1667876251464335361.

                Calendar compiled on Sunday 11 Jun 2023 at 13:31:03 (UTC+02:00) by run https://github.com/beyarkay/eskom-calendar/actions/runs/5235724964.

                eskom-calendar version: https://github.com/beyarkay/eskom-calendar/tree/5cdc7ed3c3648a456d42af8728075b09af5ec019

Mon Jun 12 2023
    21:00-00:00 🔌BuffaloCityBlock1 Stage 3 😟
                This event shows that there will be loadshedding on Monday from 21:00 to Tuesday at 00:00 in the load shedding area buffalo-city-block-1.

                When new loadshedding schedules are announced, your calendar will be automatically updated to show when your power will be off.

                While these new schedules are calculated immediately, it can sometimes take a bit of time for your calendar app (ie Google Calendar, Apple iCalendar, or Outlook) to fetch the updated schedules. Often you can set the update frequency in the settings of your calendar app.

                ---

                Incorrect? Open an issue here: https://github.com/beyarkay/eskom-calendar/issues/new

                Generated by Boyd Kane's eskom-calendar: https://eskomcalendar.co.za/ec?calendar=buffalo-city-block-1.ics.

                National loadshedding information scraped from https://twitter.com/Eskom_SA/status/1667876251464335361.

                Calendar compiled on Sunday 11 Jun 2023 at 13:31:03 (UTC+02:00) by run https://github.com/beyarkay/eskom-calendar/actions/runs/5235724964.

                eskom-calendar version: https://github.com/beyarkay/eskom-calendar/tree/5cdc7ed3c3648a456d42af8728075b09af5ec019

Wed Jun 14 2023
    16:00-18:00 🔌BuffaloCityBlock1 Stage 3 😟
                This event shows that there will be loadshedding on Wednesday from 16:00 to Wednesday at 18:00 in the load shedding area buffalo-city-block-1.

                When new loadshedding schedules are announced, your calendar will be automatically updated to show when your power will be off.

                While these new schedules are calculated immediately, it can sometimes take a bit oftime for your calendar app (ie Google Calendar, Apple iCalendar, or Outlook) to fetch the updated schedules. Often you can set the update frequency in the settings of your calendar app.

                ---

                Incorrect? Open an issue here: https://github.com/beyarkay/eskom-calendar/issues/new

                Generated byBoyd Kane's eskom-calendar: https://eskomcalendar.co.za/ec?calendar=buffalo-city-block-1.ics.

                National loadshedding information scraped from https://twitter.com/Eskom_SA/status/1667876251464335361.

                Calendar compiled onSunday 11 Jun 2023 at 13:31:03 (UTC+02:00) by run https://github.com/beyarkay/eskom-calendar/actions/runs/5235724964.

                eskom-calendar version: https://github.com/beyarkay/eskom-calendar/tree/5cdc7ed3c3648a456d42af8728075b09af5ec019

    18:00-19:00 ⚠️  End of schedule
                This is the end of the known loadshedding schedule.

                Unfortunately only a few days worth of loadshedding schedules are released at a time. An update to the loadshedding schedule is usually announced a day or two before the previous schedule runs out, so this event will move in your calendar as new schedules are announced.

                You don't have to do anything, but just know that there might be loadshedding after this point, but there also might not. It's impossible to say for sure.

                Incorrect? Open an issuehere: https://github.com/beyarkay/eskom-calendar/issues/new

                ---
                Generated by Boyd Kane's eskom-calendar: https://github.com/beyarkay/eskom-calendar/tree/5cdc7ed3c3648a456d42af8728075b09af5ec019

                Calendar compiled at 2023-06-11T13:31:03.330216061+00:00
```

The former is quite a bit more readable.